### PR TITLE
Moved the easing functions into separated files for modularization

### DIFF
--- a/src/ease-in-back.js
+++ b/src/ease-in-back.js
@@ -1,0 +1,7 @@
+// Slow movement backwards then fast snap to finish
+export default function easeInBack( t, magnitude = 1.70158 ) {
+
+    const scaledTime = t / 1;
+    return scaledTime * scaledTime * ( ( magnitude + 1 ) * scaledTime - magnitude );
+
+}

--- a/src/ease-in-bounce.js
+++ b/src/ease-in-bounce.js
@@ -1,0 +1,6 @@
+import easeOutBounce from './ease-out-bounce';
+
+// Bounce increasing in velocity until completion
+export default function easeInBounce( t ) {
+    return 1 - easeOutBounce( 1 - t );
+}

--- a/src/ease-in-circ.js
+++ b/src/ease-in-circ.js
@@ -1,0 +1,7 @@
+// Increasing velocity until stop
+export default function easeInCirc( t ) {
+
+    const scaledTime = t / 1;
+    return -1 * ( Math.sqrt( 1 - scaledTime * t ) - 1 );
+
+}

--- a/src/ease-in-cubic.js
+++ b/src/ease-in-cubic.js
@@ -1,0 +1,4 @@
+// Accelerating from zero velocity
+export default function easeInCubic( t ) {
+    return t * t * t;
+}

--- a/src/ease-in-elastic.js
+++ b/src/ease-in-elastic.js
@@ -1,0 +1,19 @@
+// Bounces slowly then quickly to finish
+export default function easeInElastic( t, magnitude = 0.7 ) {
+
+    if( t === 0 || t === 1 ) {
+        return t;
+    }
+
+    const scaledTime = t / 1;
+    const scaledTime1 = scaledTime - 1;
+
+    const p = 1 - magnitude;
+    const s = p / ( 2 * Math.PI ) * Math.asin( 1 );
+
+    return -(
+        Math.pow( 2, 10 * scaledTime1 ) *
+        Math.sin( ( scaledTime1 - s ) * ( 2 * Math.PI ) / p )
+    );
+
+}

--- a/src/ease-in-expo.js
+++ b/src/ease-in-expo.js
@@ -1,0 +1,10 @@
+// Accelerate exponentially until finish
+export default function easeInExpo( t ) {
+
+    if( t === 0 ) {
+        return 0;
+    }
+
+    return Math.pow( 2, 10 * ( t - 1 ) );
+
+}

--- a/src/ease-in-out-back.js
+++ b/src/ease-in-out-back.js
@@ -1,0 +1,21 @@
+// Slow movement backwards, fast snap to past finish, slow resolve to finish
+export default function easeInOutBack( t, magnitude = 1.70158 ) {
+
+    const scaledTime = t * 2;
+    const scaledTime2 = scaledTime - 2;
+
+    const s = magnitude * 1.525;
+
+    if( scaledTime < 1) {
+
+        return 0.5 * scaledTime * scaledTime * (
+            ( ( s + 1 ) * scaledTime ) - s
+        );
+
+    }
+
+    return 0.5 * (
+        scaledTime2 * scaledTime2 * ( ( s + 1 ) * scaledTime2 + s ) + 2
+    );
+
+}

--- a/src/ease-in-out-bounce.js
+++ b/src/ease-in-out-bounce.js
@@ -1,0 +1,15 @@
+import easeInBounce from './ease-in-bounce';
+import easeOutBounce from './ease-out-bounce';
+
+// Bounce in and bounce out
+export default function easeInOutBounce( t ) {
+
+    if( t < 0.5 ) {
+
+        return easeInBounce( t * 2 ) * 0.5;
+
+    }
+
+    return ( easeOutBounce( ( t * 2 ) - 1 ) * 0.5 ) + 0.5;
+
+}

--- a/src/ease-in-out-circ.js
+++ b/src/ease-in-out-circ.js
@@ -1,0 +1,13 @@
+// Fast increase in velocity, fast decrease in velocity
+export default function easeInOutCirc( t ) {
+
+    const scaledTime = t * 2;
+    const scaledTime1 = scaledTime - 2;
+
+    if( scaledTime < 1 ) {
+        return -0.5 * ( Math.sqrt( 1 - scaledTime * scaledTime ) - 1 );
+    }
+
+    return 0.5 * ( Math.sqrt( 1 - scaledTime1 * scaledTime1 ) + 1 );
+
+}

--- a/src/ease-in-out-cubic.js
+++ b/src/ease-in-out-cubic.js
@@ -1,0 +1,4 @@
+// Acceleration until halfway, then deceleration
+export default function easeInOutCubic( t ) {
+    return t < 0.5 ? 4 * t * t * t : ( t - 1 ) * ( 2 * t - 2 ) * ( 2 * t - 2 ) + 1;
+}

--- a/src/ease-in-out-elastic.js
+++ b/src/ease-in-out-elastic.js
@@ -1,0 +1,27 @@
+// Slow start and end, two bounces sandwich a fast motion
+export default function easeInOutElastic( t, magnitude = 0.65 ) {
+
+    const p = 1 - magnitude;
+
+    if( t === 0 || t === 1 ) {
+        return t;
+    }
+
+    const scaledTime = t * 2;
+    const scaledTime1 = scaledTime - 1;
+
+    const s = p / ( 2 * Math.PI ) * Math.asin( 1 );
+
+    if( scaledTime < 1 ) {
+        return -0.5 * (
+            Math.pow( 2, 10 * scaledTime1 ) *
+            Math.sin( ( scaledTime1 - s ) * ( 2 * Math.PI ) / p )
+        );
+    }
+
+    return (
+        Math.pow( 2, -10 * scaledTime1 ) *
+        Math.sin( ( scaledTime1 - s ) * ( 2 * Math.PI ) / p ) * 0.5
+    ) + 1;
+
+}

--- a/src/ease-in-out-expo.js
+++ b/src/ease-in-out-expo.js
@@ -1,0 +1,17 @@
+// Exponential acceleration and deceleration
+export default function easeInOutExpo( t ) {
+
+    if( t === 0 || t === 1 ) {
+        return t;
+    }
+
+    const scaledTime = t * 2;
+    const scaledTime1 = scaledTime - 1;
+
+    if( scaledTime < 1 ) {
+        return 0.5 * Math.pow( 2, 10 * ( scaledTime1 ) );
+    }
+
+    return 0.5 * ( -Math.pow( 2, -10 * scaledTime1 ) + 2 );
+
+}

--- a/src/ease-in-out-quad.js
+++ b/src/ease-in-out-quad.js
@@ -1,0 +1,4 @@
+// Acceleration until halfway, then deceleration
+export default function easeInOutQuad( t ) {
+    return t < 0.5 ? 2 * t * t : - 1 + ( 4 - 2 * t ) * t;
+}

--- a/src/ease-in-out-quart.js
+++ b/src/ease-in-out-quart.js
@@ -1,0 +1,5 @@
+// Acceleration until halfway, then deceleration
+export default function easeInOutQuart( t ) {
+    const t1 = t - 1;
+    return t < 0.5 ? 8 * t * t * t * t : 1 - 8 * t1 * t1 * t1 * t1;
+}

--- a/src/ease-in-out-quint.js
+++ b/src/ease-in-out-quint.js
@@ -1,0 +1,5 @@
+// Acceleration until halfway, then deceleration
+export default function easeInOutQuint( t ) {
+    const t1 = t - 1;
+    return t < 0.5 ? 16 * t * t * t * t * t : 1 + 16 * t1 * t1 * t1 * t1 * t1;
+}

--- a/src/ease-in-out-sine.js
+++ b/src/ease-in-out-sine.js
@@ -1,0 +1,4 @@
+// Slight acceleration at beginning and slight deceleration at end
+export default function easeInOutSine( t ) {
+    return -0.5 * ( Math.cos( Math.PI * t ) - 1 );
+}

--- a/src/ease-in-quad.js
+++ b/src/ease-in-quad.js
@@ -1,0 +1,4 @@
+// Accelerating from zero velocity
+export default function easeInQuad( t ) {
+    return t * t;
+}

--- a/src/ease-in-quart.js
+++ b/src/ease-in-quart.js
@@ -1,0 +1,4 @@
+// Accelerating from zero velocity
+export default function easeInQuart( t ) {
+    return t * t * t * t;
+}

--- a/src/ease-in-quint.js
+++ b/src/ease-in-quint.js
@@ -1,0 +1,4 @@
+// Accelerating from zero velocity
+export default function easeInQuint( t ) {
+    return t * t * t * t * t;
+}

--- a/src/ease-in-sine.js
+++ b/src/ease-in-sine.js
@@ -1,0 +1,4 @@
+// Slight acceleration from zero to full speed
+export default function easeInSine( t ) {
+    return -1 * Math.cos( t * ( Math.PI / 2 ) ) + 1;
+}

--- a/src/ease-out-back.js
+++ b/src/ease-out-back.js
@@ -1,0 +1,10 @@
+// Fast snap to backwards point then slow resolve to finish
+export default function easeOutBack( t, magnitude = 1.70158 ) {
+
+    const scaledTime = ( t / 1 ) - 1;
+
+    return (
+        scaledTime * scaledTime * ( ( magnitude + 1 ) * scaledTime + magnitude )
+    ) + 1;
+
+}

--- a/src/ease-out-bounce.js
+++ b/src/ease-out-bounce.js
@@ -1,0 +1,27 @@
+// Bounce to completion
+export default function easeOutBounce( t ) {
+
+    const scaledTime = t / 1;
+
+    if( scaledTime < ( 1 / 2.75 ) ) {
+
+        return 7.5625 * scaledTime * scaledTime;
+
+    } else if( scaledTime < ( 2 / 2.75 ) ) {
+
+        const scaledTime2 = scaledTime - ( 1.5 / 2.75 );
+        return ( 7.5625 * scaledTime2 * scaledTime2 ) + 0.75;
+
+    } else if( scaledTime < ( 2.5 / 2.75 ) ) {
+
+        const scaledTime2 = scaledTime - ( 2.25 / 2.75 );
+        return ( 7.5625 * scaledTime2 * scaledTime2 ) + 0.9375;
+
+    } else {
+
+        const scaledTime2 = scaledTime - ( 2.625 / 2.75 );
+        return ( 7.5625 * scaledTime2 * scaledTime2 ) + 0.984375;
+
+    }
+
+}

--- a/src/ease-out-circ.js
+++ b/src/ease-out-circ.js
@@ -1,0 +1,7 @@
+// Start fast, decreasing velocity until stop
+export default function easeOutCirc( t ) {
+
+    const t1 = t - 1;
+    return Math.sqrt( 1 - t1 * t1 );
+
+}

--- a/src/ease-out-cubic.js
+++ b/src/ease-out-cubic.js
@@ -1,0 +1,5 @@
+// Decelerating to zero velocity
+export default function easeOutCubic( t ) {
+    const t1 = t - 1;
+    return t1 * t1 * t1 + 1;
+}

--- a/src/ease-out-elastic.js
+++ b/src/ease-out-elastic.js
@@ -1,0 +1,17 @@
+// Fast acceleration, bounces to zero
+export default function easeOutElastic( t, magnitude = 0.7 ) {
+
+    const p = 1 - magnitude;
+    const scaledTime = t * 2;
+
+    if( t === 0 || t === 1 ) {
+        return t;
+    }
+
+    const s = p / ( 2 * Math.PI ) * Math.asin( 1 );
+    return (
+        Math.pow( 2, -10 * scaledTime ) *
+        Math.sin( ( scaledTime - s ) * ( 2 * Math.PI ) / p )
+    ) + 1;
+
+}

--- a/src/ease-out-expo.js
+++ b/src/ease-out-expo.js
@@ -1,0 +1,10 @@
+// Initial exponential acceleration slowing to stop
+export default function easeOutExpo( t ) {
+
+    if( t === 1 ) {
+        return 1;
+    }
+
+    return ( -Math.pow( 2, -10 * t ) + 1 );
+
+}

--- a/src/ease-out-quad.js
+++ b/src/ease-out-quad.js
@@ -1,0 +1,4 @@
+// Decelerating to zero velocity
+export default function easeOutQuad( t ) {
+    return t * ( 2 - t );
+}

--- a/src/ease-out-quart.js
+++ b/src/ease-out-quart.js
@@ -1,0 +1,5 @@
+// Decelerating to zero velocity
+export default function easeOutQuart( t ) {
+    const t1 = t - 1;
+    return 1 - t1 * t1 * t1 * t1;
+}

--- a/src/ease-out-quint.js
+++ b/src/ease-out-quint.js
@@ -1,0 +1,5 @@
+// Decelerating to zero velocity
+export default function easeOutQuint( t ) {
+    const t1 = t - 1;
+    return 1 + t1 * t1 * t1 * t1 * t1;
+}

--- a/src/ease-out-sine.js
+++ b/src/ease-out-sine.js
@@ -1,0 +1,4 @@
+// Slight deceleration at the end
+export default function easeOutSine( t ) {
+    return Math.sin( t * ( Math.PI / 2 ) );
+}

--- a/src/easing.js
+++ b/src/easing.js
@@ -1,308 +1,33 @@
 // Based on https://gist.github.com/gre/1650294
 
-// No easing, no acceleration
-export function linear( t ) {
-    return t;
-}
-
-// Slight acceleration from zero to full speed
-export function easeInSine( t ) {
-    return -1 * Math.cos( t * ( Math.PI / 2 ) ) + 1;
-}
-
-// Slight deceleration at the end
-export function easeOutSine( t ) {
-    return Math.sin( t * ( Math.PI / 2 ) );
-}
-
-// Slight acceleration at beginning and slight deceleration at end
-export function easeInOutSine( t ) {
-    return -0.5 * ( Math.cos( Math.PI * t ) - 1 );
-}
-
-// Accelerating from zero velocity
-export function easeInQuad( t ) {
-    return t * t;
-}
-
-// Decelerating to zero velocity
-export function easeOutQuad( t ) {
-    return t * ( 2 - t );
-}
-
-// Acceleration until halfway, then deceleration
-export function easeInOutQuad( t ) {
-    return t < 0.5 ? 2 * t * t : - 1 + ( 4 - 2 * t ) * t;
-}
-
-// Accelerating from zero velocity
-export function easeInCubic( t ) {
-    return t * t * t;
-}
-
-// Decelerating to zero velocity
-export function easeOutCubic( t ) {
-    const t1 = t - 1;
-    return t1 * t1 * t1 + 1;
-}
-
-// Acceleration until halfway, then deceleration
-export function easeInOutCubic( t ) {
-    return t < 0.5 ? 4 * t * t * t : ( t - 1 ) * ( 2 * t - 2 ) * ( 2 * t - 2 ) + 1;
-}
-
-// Accelerating from zero velocity
-export function easeInQuart( t ) {
-    return t * t * t * t;
-}
-
-// Decelerating to zero velocity
-export function easeOutQuart( t ) {
-    const t1 = t - 1;
-    return 1 - t1 * t1 * t1 * t1;
-}
-
-// Acceleration until halfway, then deceleration
-export function easeInOutQuart( t ) {
-    const t1 = t - 1;
-    return t < 0.5 ? 8 * t * t * t * t : 1 - 8 * t1 * t1 * t1 * t1;
-}
-
-// Accelerating from zero velocity
-export function easeInQuint( t ) {
-    return t * t * t * t * t;
-}
-
-// Decelerating to zero velocity
-export function easeOutQuint( t ) {
-    const t1 = t - 1;
-    return 1 + t1 * t1 * t1 * t1 * t1;
-}
-
-// Acceleration until halfway, then deceleration
-export function easeInOutQuint( t ) {
-    const t1 = t - 1;
-    return t < 0.5 ? 16 * t * t * t * t * t : 1 + 16 * t1 * t1 * t1 * t1 * t1;
-}
-
-// Accelerate exponentially until finish
-export function easeInExpo( t ) {
-
-    if( t === 0 ) {
-        return 0;
-    }
-
-    return Math.pow( 2, 10 * ( t - 1 ) );
-
-}
-
-// Initial exponential acceleration slowing to stop
-export function easeOutExpo( t ) {
-
-    if( t === 1 ) {
-        return 1;
-    }
-
-    return ( -Math.pow( 2, -10 * t ) + 1 );
-
-}
-
-// Exponential acceleration and deceleration
-export function easeInOutExpo( t ) {
-    
-    if( t === 0 || t === 1 ) {
-        return t;
-    }
-
-    const scaledTime = t * 2;
-    const scaledTime1 = scaledTime - 1;
-
-    if( scaledTime < 1 ) {
-        return 0.5 * Math.pow( 2, 10 * ( scaledTime1 ) );
-    }
-
-    return 0.5 * ( -Math.pow( 2, -10 * scaledTime1 ) + 2 );
-
-}
-
-// Increasing velocity until stop
-export function easeInCirc( t ) {
-
-    const scaledTime = t / 1;
-    return -1 * ( Math.sqrt( 1 - scaledTime * t ) - 1 );
-
-}
-
-// Start fast, decreasing velocity until stop
-export function easeOutCirc( t ) {
-
-    const t1 = t - 1;
-    return Math.sqrt( 1 - t1 * t1 );
-
-}
-
-// Fast increase in velocity, fast decrease in velocity
-export function easeInOutCirc( t ) {
-
-    const scaledTime = t * 2;
-    const scaledTime1 = scaledTime - 2;
-
-    if( scaledTime < 1 ) {
-        return -0.5 * ( Math.sqrt( 1 - scaledTime * scaledTime ) - 1 );
-    }
-
-    return 0.5 * ( Math.sqrt( 1 - scaledTime1 * scaledTime1 ) + 1 );
-
-}
-
-// Slow movement backwards then fast snap to finish
-export function easeInBack( t, magnitude = 1.70158 ) {
-
-    const scaledTime = t / 1;
-    return scaledTime * scaledTime * ( ( magnitude + 1 ) * scaledTime - magnitude );
-
-}
-
-// Fast snap to backwards point then slow resolve to finish
-export function easeOutBack( t, magnitude = 1.70158 ) {
-
-    const scaledTime = ( t / 1 ) - 1;
-    
-    return (
-        scaledTime * scaledTime * ( ( magnitude + 1 ) * scaledTime + magnitude )
-    ) + 1;
-
-}
-
-// Slow movement backwards, fast snap to past finish, slow resolve to finish
-export function easeInOutBack( t, magnitude = 1.70158 ) {
-
-    const scaledTime = t * 2;
-    const scaledTime2 = scaledTime - 2;
-
-    const s = magnitude * 1.525;
-
-    if( scaledTime < 1) {
-
-        return 0.5 * scaledTime * scaledTime * (
-            ( ( s + 1 ) * scaledTime ) - s
-        );
-
-    }
-
-    return 0.5 * (
-        scaledTime2 * scaledTime2 * ( ( s + 1 ) * scaledTime2 + s ) + 2
-    );
-
-}
-// Bounces slowly then quickly to finish
-export function easeInElastic( t, magnitude = 0.7 ) {
-
-    if( t === 0 || t === 1 ) {
-        return t;
-    }
-
-    const scaledTime = t / 1;
-    const scaledTime1 = scaledTime - 1;
-
-    const p = 1 - magnitude;
-    const s = p / ( 2 * Math.PI ) * Math.asin( 1 );
-
-    return -(
-        Math.pow( 2, 10 * scaledTime1 ) *
-        Math.sin( ( scaledTime1 - s ) * ( 2 * Math.PI ) / p )
-    );
-
-}
-
-// Fast acceleration, bounces to zero
-export function easeOutElastic( t, magnitude = 0.7 ) {
-
-    const p = 1 - magnitude;
-    const scaledTime = t * 2;
-
-    if( t === 0 || t === 1 ) {
-        return t;
-    }
-
-    const s = p / ( 2 * Math.PI ) * Math.asin( 1 );
-    return (
-        Math.pow( 2, -10 * scaledTime ) *
-        Math.sin( ( scaledTime - s ) * ( 2 * Math.PI ) / p )
-    ) + 1;
-
-}
-
-// Slow start and end, two bounces sandwich a fast motion
-export function easeInOutElastic( t, magnitude = 0.65 ) {
-
-    const p = 1 - magnitude;
-
-    if( t === 0 || t === 1 ) {
-        return t;
-    }
-
-    const scaledTime = t * 2;
-    const scaledTime1 = scaledTime - 1;
-    
-    const s = p / ( 2 * Math.PI ) * Math.asin( 1 );
-
-    if( scaledTime < 1 ) {
-        return -0.5 * (
-            Math.pow( 2, 10 * scaledTime1 ) *
-            Math.sin( ( scaledTime1 - s ) * ( 2 * Math.PI ) / p )
-        );
-    }
-
-    return (
-        Math.pow( 2, -10 * scaledTime1 ) *
-        Math.sin( ( scaledTime1 - s ) * ( 2 * Math.PI ) / p ) * 0.5
-    ) + 1;
-
-}
-
-// Bounce to completion
-export function easeOutBounce( t ) {
-
-    const scaledTime = t / 1;
-
-    if( scaledTime < ( 1 / 2.75 ) ) {
-
-        return 7.5625 * scaledTime * scaledTime;
-
-    } else if( scaledTime < ( 2 / 2.75 ) ) {
-
-        const scaledTime2 = scaledTime - ( 1.5 / 2.75 );
-        return ( 7.5625 * scaledTime2 * scaledTime2 ) + 0.75;
-
-    } else if( scaledTime < ( 2.5 / 2.75 ) ) {
-
-        const scaledTime2 = scaledTime - ( 2.25 / 2.75 );
-        return ( 7.5625 * scaledTime2 * scaledTime2 ) + 0.9375;
-
-    } else {
-
-        const scaledTime2 = scaledTime - ( 2.625 / 2.75 );
-        return ( 7.5625 * scaledTime2 * scaledTime2 ) + 0.984375;
-
-    }
-
-}
-
-// Bounce increasing in velocity until completion
-export function easeInBounce( t ) {
-    return 1 - easeOutBounce( 1 - t );
-}
-
-// Bounce in and bounce out
-export function easeInOutBounce( t ) {
-
-    if( t < 0.5 ) {
-
-        return easeInBounce( t * 2 ) * 0.5;
-        
-    }
-
-    return ( easeOutBounce( ( t * 2 ) - 1 ) * 0.5 ) + 0.5;
-
-}
+export linear from './linear';
+export easeInSine from './ease-in-sine';
+export easeOutSine from './ease-out-sine';
+export easeInOutSine from './ease-in-out-sine';
+export easeInQuad from './ease-in-quad';
+export easeOutQuad from './ease-out-quad';
+export easeInOutQuad from './ease-in-out-quad';
+export easeInCubic from './ease-in-cubic';
+export easeOutCubic from './ease-out-cubic';
+export easeInOutCubic from '/ease-in-out-cubic';
+export easeInQuart from './ease-in-quart';
+export easeOutQuart from './ease-out-quart';
+export easeInOutQuart from './ease-in-out-quart';
+export easeInQuint from './ease-in-quint';
+export easeOutQuint from './ease-out-quint';
+export easeInOutQuint from './ease-in-out-quint';
+export easeInExpo from './ease-in-expo';
+export easeOutExpo from './ease-out-expo';
+export easeInOutExpo from './ease-in-out-expo';
+export easeInCirc from './ease-in-circ';
+export easeOutCirc from './ease-out-circ';
+export easeInOutCirc from './ease-in-out-circ';
+export easeInBack from './ease-in-back';
+export easeOutBack from './ease-out-back';
+export easeInOutBack from './ease-in-out-back';
+export easeInElastic from './ease-in-elastic';
+export easeOutElastic from './ease-out-elastic';
+export easeInOutElastic from './ease-in-out-elastic';
+export easeInBounce from './ease-in-bounce';
+export easeOutBounce from './ease-out-bounce';
+export easeInOutBounce from './ease-in-out-bounce';

--- a/src/linear.js
+++ b/src/linear.js
@@ -1,0 +1,4 @@
+// No easing, no acceleration
+export default function linear( t ) {
+    return t;
+}


### PR DESCRIPTION
Sometimes, we only need a few easing functions for our project. If we aren't using Rollup or Webpack 2.0, we compile the hole `easing.js` file, even using ES6 modules.

I moved all the easing functions into separated files, and the `easing.js` file only export all the functions now. So, in our projects we can use the way we did before, but we can also import a single function, like this:

``` javascript
import linear from 'easing-utils/linear';
```

And then, we'll only have in our bundled/minified file the linear function, instead of all the other needless files - generating a smaller footprint.

PS: Unfortunately, I couldn't run/test it because your build process is not working in my Windows 10 machine. I would be glad if you could take some time to see if it's working as expected.
